### PR TITLE
Update vite.config.ts

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig(({ mode }) => ({
     host: "::",
     port: 8080,
   },
-  base: "skribh",
+  base: "/",
   plugins: [
     react(),
     mode === 'development' &&


### PR DESCRIPTION
updated 'base' to '/' instead of 'skribh', so it can direct to 'https://skribh.com/' instead of 'https://skribh.com/skribh'