### PR TITLE
Update hero section wording for prehospital care focus

### DIFF
--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -16,7 +16,7 @@ export const HeroSection = () => {
               transition={{ duration: 0.6 }}
               className="text-6xl md:text-7xl font-bold mb-8 leading-none"
             >
-              Intelligence That <span className="text-red-600">Unlocks Impact</span>
+              Revolutionizing Prehospital Care with <span className="text-red-600">AI-Driven Documentation</span>
             </motion.h1>
             <motion.p 
               initial={{ opacity: 0, y: 20 }}


### PR DESCRIPTION
This PR updates the main hero section headline from "Intelligence That Unlocks Impact" to "Revolutionizing Prehospital Care with AI-Driven Documentation".

## Changes made:
- Modified the hero text in `src/components/landing/HeroSection.tsx` to better emphasize our focus on prehospital care and AI-driven documentation solutions
- Maintains the existing styling with the highlighted text in red

## Technical workflow:
1. Created a new branch `kaju-wording-change` from main
2. Used grep search to locate the text "Intelligence That Unlocks Impact" in the codebase
3. Found the target text in `src/components/landing/HeroSection.tsx`
4. Modified the text using file replacement while preserving the React component structure and styling
5. Committed the change with a descriptive commit message

## Issues encountered:
- Initially had a JSON formatting error when attempting to use the file replacement tool (missing the AllowMultiple parameter)
- Fixed the error by properly formatting the replacement parameters
